### PR TITLE
chore: remove releases folder

### DIFF
--- a/releases/v0.1.0.md
+++ b/releases/v0.1.0.md
@@ -1,9 +1,0 @@
-🎉 xk6-sql-driver-azuresql `v0.1.0` is here!
-
-This is the initial release after the modularization of the [xk6-sql](https://github.com/grafana/xk6-sql) extension. Built for `v1.0.0` of the [xk6-sql](https://github.com/grafana/xk6-sql) extension.
-
-Build:
-
-```bash
-xk6 build --with github.com/grafana/xk6-sql@latest --with github.com/grafana/xk6-sql-driver-azuresql@latest
-```


### PR DESCRIPTION
## What

Removes the root-level `releases/` folder.

## Why

Release notes are no longer maintained as files inside a committed
`releases/` folder. Going forward, release notes are published
exclusively through [GitHub Releases](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases).

Keeping a separate `releases/` directory in the repository duplicates the
information already captured by GitHub Releases and adds maintenance
overhead with every release. Removing it keeps a single source of truth.