### PR TITLE
chore(renovate): enable gomodTidy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>grafana/grafana-renovate-config//presets/k6/k6-engine-base.json"
+  ],
+  "postUpdateOptions": [
+    "gomodTidy"
   ]
 }


### PR DESCRIPTION
Adds `postUpdateOptions: ["gomodTidy"]` so Renovate runs `go mod tidy` after each update.

**Why:** the shared `k6-engine-base` preset disables indirect-dependency PRs. `go.k6.io/k6/v2` is indirect here (inherited via `grafana/xk6-sql`), so after an xk6-sql bump the recorded k6 version goes stale. With `gomodTidy`, the indirect k6 is refreshed in lockstep with the xk6-sql update — no separate PR needed.